### PR TITLE
Fix invalid Discord invite links on Hero section and Footer component

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -73,7 +73,7 @@ function Footer() {
                 </a>
 
                 <a
-                  href="https://discord.gg/ZfFnhhHDhK"
+                  href="https://discord.gg/RbSCJWZpaw"
                   target={'_blank'}
                   className={'transition-all hover:text-blue-500'}
                 >

--- a/src/components/sections/Hero.jsx
+++ b/src/components/sections/Hero.jsx
@@ -43,7 +43,7 @@ function Hero() {
               </a>
 
               <a
-                href={'https://discord.gg/ZfFnhhHDhK'}
+                href={'https://discord.gg/RbSCJWZpaw'}
                 target={'_blank'}
                 className={
                   'shadow-lg shadow-blue-800/50 w-full max-w-2xs text-xl px-4 py-2 bg-transparent border border-blue-900 rounded-sm transition-all hover:bg-blue-950 sm:w-2xs md:w-fit'


### PR DESCRIPTION
## 📌 Description

This pull request includes updates to the Discord invite link in the `Footer` and `Hero` components to ensure users are directed to the correct server.

## 🔍 Related Issues

Closes #2 
Closes #3 
Closes #4 

## Evidence

![GIF of Henna Software landing page showing Discord invite links working](https://github.com/user-attachments/assets/a937b398-4426-4b15-a34b-0472998173bf)


## ✨ Changes Made

* [`src/components/Footer.jsx`](diffhunk://#diff-618acf142786bf7414152d4982d3d647b5ca1f96edaed7385ba0f17b46741b65L76-R76): Updated the Discord invite link from `https://discord.gg/ZfFnhhHDhK` to `https://discord.gg/RbSCJWZpaw` in the `Footer` component.
* [`src/components/sections/Hero.jsx`](diffhunk://#diff-8bb8086e58069f06dc2597a527ec6d7b1ad9ccd716cf9c2f5f793ab91d8e45e3L46-R46): Updated the Discord invite link from `https://discord.gg/ZfFnhhHDhK` to `https://discord.gg/RbSCJWZpaw` in the `Hero` component.

## ✅ Checklist

- [x] My code follows the project's coding standards and guidelines
- [x] I have tested the changes locally to ensure they work as expected
- [x] No new warnings or errors in the console
- [x] The UI and functionality are responsive across different screen sizes.
- [x] I have updated the documentation (if necessary)

## 🚀 Additional Notes

N/A